### PR TITLE
Fix SetStorageBuffer binding indexing

### DIFF
--- a/include/raygpu.h
+++ b/include/raygpu.h
@@ -738,6 +738,7 @@ externcvar WGPUBuffer vbo_buf;
 externcvar VertexArray* renderBatchVAO;
 externcvar DescribedBuffer* renderBatchVBO;
 externcvar PrimitiveType current_drawmode;
+externcvar DescribedComputePipeline* g_activeComputePipeline;
 externcvar char telegrama_render1[];
 externcvar char telegrama_render2[];
 externcvar char telegrama_render3[];

--- a/src/raygpu.c
+++ b/src/raygpu.c
@@ -240,6 +240,7 @@ WGPUBuffer vbo_buf = 0;
 VertexArray* renderBatchVAO;
 DescribedBuffer* renderBatchVBO;
 PrimitiveType current_drawmode;
+DescribedComputePipeline* g_activeComputePipeline = NULL;
 //DescribedBuffer vbomap;
 
 #if RAYGPU_NO_INLINE_FUNCTIONS == 1
@@ -2192,26 +2193,54 @@ Shader GetActiveShader(){
 }
 
 void SetTexture                   (uint32_t index, Texture tex){
-    SetShaderTexture(GetActiveShader(), index, tex);
+    if(g_activeComputePipeline){
+        SetBindgroupTexture(&g_activeComputePipeline->bindGroup, index, tex);
+    } else {
+        SetShaderTexture(GetActiveShader(), index, tex);
+    }
 }
 RGAPI void SetTextureView (uint32_t index, WGPUTextureView tex){
-    ShaderImpl* sh = allocatedShaderIDs_shc + GetActiveShader().id;
-    SetBindgroupTextureView(&sh->bindGroup, index, tex);
+    if(g_activeComputePipeline){
+        SetBindgroupTextureView(&g_activeComputePipeline->bindGroup, index, tex);
+    } else {
+        ShaderImpl* sh = allocatedShaderIDs_shc + GetActiveShader().id;
+        SetBindgroupTextureView(&sh->bindGroup, index, tex);
+    }
 }
 void SetSampler                   (uint32_t index, DescribedSampler sampler){
-    SetShaderSampler (GetActiveShader(), index, sampler);
+    if(g_activeComputePipeline){
+        SetBindgroupSampler(&g_activeComputePipeline->bindGroup, index, sampler);
+    } else {
+        SetShaderSampler (GetActiveShader(), index, sampler);
+    }
 }
 void SetUniformBuffer             (uint32_t index, DescribedBuffer* buffer){
-    SetShaderUniformBuffer (GetActiveShader(), index, buffer);
+    if(g_activeComputePipeline){
+        SetBindgroupUniformBuffer(&g_activeComputePipeline->bindGroup, index, buffer);
+    } else {
+        SetShaderUniformBuffer (GetActiveShader(), index, buffer);
+    }
 }
 void SetStorageBuffer             (uint32_t index, DescribedBuffer* buffer){
-    SetShaderStorageBuffer(GetActiveShader(), index, buffer);
+    if(g_activeComputePipeline){
+        SetBindgroupStorageBuffer(&g_activeComputePipeline->bindGroup, index, buffer);
+    } else {
+        SetShaderStorageBuffer(GetActiveShader(), index, buffer);
+    }
 }
 void SetUniformBufferData         (uint32_t index, const void* data, size_t size){
-    SetShaderUniformBufferData(GetActiveShader(), index, data, size);
+    if(g_activeComputePipeline){
+        SetBindgroupUniformBufferData(&g_activeComputePipeline->bindGroup, index, data, size);
+    } else {
+        SetShaderUniformBufferData(GetActiveShader(), index, data, size);
+    }
 }
 void SetStorageBufferData         (uint32_t index, const void* data, size_t size){
-    SetShaderStorageBufferData(GetActiveShader(), index, data, size);
+    if(g_activeComputePipeline){
+        SetBindgroupStorageBufferData(&g_activeComputePipeline->bindGroup, index, data, size);
+    } else {
+        SetShaderStorageBufferData(GetActiveShader(), index, data, size);
+    }
 }
 
 void SetBindgroupUniformBuffer (DescribedBindGroup* bg, uint32_t index, DescribedBuffer* buffer){


### PR DESCRIPTION
Previously `SetStorageBuffer` would always assume the renderpass's bind group even if we have a compute pass active.

Repro:
```cpp
#include <raygpu.h>
#include <cstdio>

void setup() {
    const char* shaderCode = R"(
@group(0) @binding(0) var<storage, read_write> b0: array<u32>;
@group(0) @binding(1) var<storage, read_write> b1: array<u32>;
@group(0) @binding(2) var<storage, read_write> b2: array<u32>;
@group(0) @binding(3) var<storage, read_write> b3: array<u32>;
@group(0) @binding(4) var<storage, read_write> b4: array<u32>;

@compute @workgroup_size(1)
fn main() {
    b4[0] = 123u;
}
    )";

    ResourceTypeDescriptor resources[] = {
        { storage_buffer, 0, 0, access_type_readwrite, we_dont_know, RGShaderStage_Compute },
        { storage_buffer, 0, 1, access_type_readwrite, we_dont_know, RGShaderStage_Compute },
        { storage_buffer, 0, 2, access_type_readwrite, we_dont_know, RGShaderStage_Compute },
        { storage_buffer, 0, 3, access_type_readwrite, we_dont_know, RGShaderStage_Compute },
        { storage_buffer, 0, 4, access_type_readwrite, we_dont_know, RGShaderStage_Compute },
    };

    DescribedComputePipeline* pipeline = LoadComputePipelineEx(shaderCode, resources, 5);

    DescribedBuffer* buffers[5];
    uint32_t data = 0;
    
    for(int i = 0; i < 5; i++) {
        buffers[i] = GenBufferEx(&data, sizeof(uint32_t), RGBufferUsage_Storage | RGBufferUsage_CopyDst);
    }

    BeginComputepass();
    BindComputePipeline(pipeline);

    for(int i = 0; i < 5; i++) {
        printf("SetStorageBuffer(%d, ...)\n", i); 
        SetStorageBuffer(i, buffers[i]);
    }

    DispatchCompute(1, 1, 1);
    EndComputepass();
}

void render() {
    BeginDrawing();
    ClearBackground(RAYWHITE);
    EndDrawing();
}

int main(void) {
    SetConfigFlags(FLAG_VSYNC_HINT);
    ProgramInfo program = {
        .windowWidth = 800,
        .windowHeight = 600,
        .setupFunction = setup,
        .renderFunction = render,
    };
    InitProgram(program);
    return 0;
}
```

The above would print:
```
entry count: 5
ERROR: >> Validation error: Binding entry buffer not set.
 - While validating entries[0] against { binding: 0, visibility: ShaderStage::Compute, buffer: {type: BufferBindingType::Storage, minBindingSize: 0, hasDynamicOffset: 0} }.
 - While validating [BindGroupDescriptor] against [BindGroupLayout (unlabeled)]
 - While calling [Device].CreateBindGroup([BindGroupDescriptor]).

SetStorageBuffer(0, ...)
SetStorageBuffer(1, ...)
SetStorageBuffer(2, ...)
SetStorageBuffer(3, ...)
SetStorageBuffer(4, ...)
WARNING: Trying to set entry 4 on a BindGroup with only 4 entries
```

This fixes that.