### PR TITLE
LoadComputePipelineEx accept explicit entrypoint name

### DIFF
--- a/include/raygpu.h
+++ b/include/raygpu.h
@@ -1635,7 +1635,7 @@ RGAPI void UpdateBindGroup(DescribedBindGroup* bg);
 RGAPI void UnloadBindGroup(DescribedBindGroup* bg);
 RGAPI DescribedPipeline* Relayout(DescribedPipeline* pl, VertexArray* vao);
 RGAPI DescribedComputePipeline* LoadComputePipeline(const char* shaderCode);
-RGAPI DescribedComputePipeline* LoadComputePipelineEx(const char* shaderCode, const ResourceTypeDescriptor* uniforms, uint32_t uniformCount);
+RGAPI DescribedComputePipeline* LoadComputePipelineEx(const char* shaderCode, const ResourceTypeDescriptor* uniforms, uint32_t uniformCount, const char* entryPoint);
 RGAPI DescribedRaytracingPipeline* LoadRaytracingPipeline(const DescribedShaderModule* shaderModule);
 RGAPI Shader DefaultShader(cwoid);
 RGAPI RenderSettings GetCurrentSettings(cwoid);


### PR DESCRIPTION
This allows the user to choose the entrypoint of a compute shader when creating a pipeline, so a single shader can be used in multiple pipelines