### PR TITLE
BufferSubData API

### DIFF
--- a/include/raygpu.h
+++ b/include/raygpu.h
@@ -1668,6 +1668,7 @@ RGAPI DescribedBuffer* GenVertexBuffer(const void* data, size_t size);
 RGAPI DescribedBuffer* GenBufferEx(const void* data, size_t size, RGBufferUsage usage);
 RGAPI void UnloadBuffer(DescribedBuffer* buffer);
 RGAPI void BufferData(DescribedBuffer* buffer, const void* data, size_t size);
+RGAPI void BufferSubData(DescribedBuffer *buffer, size_t offset, const void *data, size_t size);
 RGAPI void ResizeBuffer(DescribedBuffer* buffer, size_t newSize);
 RGAPI void ResizeBufferAndConserve(DescribedBuffer* buffer, size_t newSize);
 RGAPI void BindVertexBuffer(const DescribedBuffer* buffer);

--- a/src/backend_wgpu.c
+++ b/src/backend_wgpu.c
@@ -1897,6 +1897,18 @@ void BufferData(DescribedBuffer *buffer, const void *data, size_t size) {
         wgpuQueueWriteBuffer(GetQueue(), buffer->buffer, 0, data, size);
     }
 }
+
+void BufferSubData(DescribedBuffer *buffer, size_t offset, const void *data, size_t size) {
+    if (!buffer || !buffer->buffer) return;
+
+    if (offset + size > buffer->size) {
+        TRACELOG(LOG_ERROR, "BufferSubData attempt to write out of bounds");
+        return;
+    }
+
+    wgpuQueueWriteBuffer(GetQueue(), buffer->buffer, offset, data, size);
+}
+
 void ResetSyncState() {}
 
 void


### PR DESCRIPTION
BufferSubData is like BufferData, but takes an additional `offset` in the buffer as an argument.