### PR TITLE
Always pick best surface format `formats[0]`

### DIFF
--- a/src/backend_wgpu.c
+++ b/src/backend_wgpu.c
@@ -1410,18 +1410,18 @@ void negotiateSurfaceFormatAndPresentMode(const void *SurfaceHandle) {
 
     WGPUTextureFormat selectedFormat = capabilities.formats[0];
     int format_index = 0;
-    for (format_index = 0; format_index < capabilities.formatCount; format_index++) {
-        if (capabilities.formats[format_index] == WGPUTextureFormat_RGBA16Float) {
-            selectedFormat = (capabilities.formats[format_index]);
-            goto found;
-        }
-    }
-    for (format_index = 0; format_index < capabilities.formatCount; format_index++) {
-        if (capabilities.formats[format_index] == WGPUTextureFormat_BGRA8Unorm /*|| capabilities.formats[format_index] == WGPUTextureFormat_RGBA8Unorm*/) {
-            selectedFormat = (capabilities.formats[format_index]);
-            goto found;
-        }
-    }
+    //for (format_index = 0; format_index < capabilities.formatCount; format_index++) {
+    //    if (capabilities.formats[format_index] == WGPUTextureFormat_RGBA16Float) {
+    //        selectedFormat = (capabilities.formats[format_index]);
+    //        goto found;
+    //    }
+    //}
+    //for (format_index = 0; format_index < capabilities.formatCount; format_index++) {
+    //    if (capabilities.formats[format_index] == WGPUTextureFormat_BGRA8Unorm /*|| capabilities.formats[format_index] == WGPUTextureFormat_RGBA8Unorm*/) {
+    //        selectedFormat = (capabilities.formats[format_index]);
+    //        goto found;
+    //    }
+    //}
 found:
     #ifdef __EMSCRIPTEN__
     selectedFormat = WGPUTextureFormat_BGRA8Unorm;


### PR DESCRIPTION
This fixes the following crash with Dawn by letting it select the first supported format (which is also supposed to be the best one):
```
INFO: Using adapter nvidia NVIDIA GeForce RTX 2060 SUPER
INFO: Using adapter NVIDIA GeForce RTX 2060 SUPERNVIDIA: 581.80 581.80.0.0∩
INFO: Adapter description: NVIDIA: 581.80 581.80.0.0
INFO: Adapter architecture: turing
INFO: Vulkan renderer running on Dedicated GPU
...
INFO: Hello!
INFO: Working directory: C:\Code\probe\build
INFO: Successfully loaded 1 x 1 texture from image
INFO: Loaded whitepixel texture
Setting 1.000000
On platform Win32
WARNING: 1.000000
INFO: Created surface: 00000209EF1AC0B0
INFO: Supported surface formats: WGPUTextureFormat_BGRA8Unorm, WGPUTextureFormat_BGRA8UnormSrgb, WGPUTextureFormat_RGBA8Unorm, WGPUTextureFormat_RGBA8UnormSrgb, WGPUTextureFormat_RGBA16Float, WGPUTextureFormat_RGB10A2Unorm, WGPUTextureFormat_RGB10A2Unorm,
INFO: Selected surface format WGPUTextureFormat_RGBA16Float
INFO: Initialized surface with WGPUPresentMode_Mailbox
FATAL: Device lost because of Unknown: Vulkan SwapChain must support TextureFormat::RGBA16Float with sRGB colorspace.
 - While handling unexpected error type Internal when allowed errors are (Validation|DeviceLost).
    at ChooseConfig (C:/Code/probe/build/_deps/dawn-src/src/dawn/native/vulkan/SwapChainVk.cpp:295)
    at Initialize (C:/Code/probe/build/_deps/dawn-src/src/dawn/native/vulkan/SwapChainVk.cpp:174)
    at Create (C:/Code/probe/build/_deps/dawn-src/src/dawn/native/vulkan/SwapChainVk.cpp:119)
    at Configure (C:/Code/probe/build/_deps/dawn-src/src/dawn/native/Surface.cpp:506)
```