### PR TITLE
Fix LoadBindGroup/UnloadBindGroup refcounting

### DIFF
--- a/src/backend_wgpu.c
+++ b/src/backend_wgpu.c
@@ -2785,8 +2785,17 @@ EntryPointSet getEntryPointsSPIRV(const uint32_t *shaderSourceSPIRV, uint32_t wo
 }
 
 void UnloadBindGroup(DescribedBindGroup *bg) {
-    free(bg->entries);
-    wgpuBindGroupRelease((WGPUBindGroup)bg->bindGroup);
+    if(bg->entries) {
+        for(size_t i = 0; i < bg->entryCount; ++i) {
+            if(bg->entries[i].buffer) wgpuBufferRelease((WGPUBuffer)bg->entries[i].buffer);
+            if(bg->entries[i].textureView) wgpuTextureViewRelease((WGPUTextureView)bg->entries[i].textureView);
+            if(bg->entries[i].sampler) wgpuSamplerRelease((WGPUSampler)bg->entries[i].sampler);
+        }
+        free(bg->entries);
+    }
+    if (bg->bindGroup) {
+        wgpuBindGroupRelease((WGPUBindGroup)bg->bindGroup);
+    }
 }
 void UnloadBindGroupLayout(DescribedBindGroupLayout *bglayout) {
     free(bglayout->entries);

--- a/src/raygpu.c
+++ b/src/raygpu.c
@@ -2339,7 +2339,21 @@ DescribedBindGroup LoadBindGroup(const DescribedBindGroupLayout* bglayout, const
     DescribedBindGroup ret  = {0};
     if(entryCount > 0){
         ret.entries = (ResourceDescriptor*)RL_CALLOC(entryCount, sizeof(ResourceDescriptor));
-        memcpy(ret.entries, entries, entryCount * sizeof(ResourceDescriptor));
+        // memcpy(ret.entries, entries, entryCount * sizeof(ResourceDescriptor));
+
+        for(size_t i = 0; i < entryCount; ++i) {
+            ret.entries[i] = entries[i];
+            
+            if(ret.entries[i].buffer) {
+                wgpuBufferAddRef((WGPUBuffer)ret.entries[i].buffer);
+            }
+            if(ret.entries[i].textureView) {
+                wgpuTextureViewAddRef((WGPUTextureView)ret.entries[i].textureView);
+            }
+            if(ret.entries[i].sampler) {
+                wgpuSamplerAddRef((WGPUSampler)ret.entries[i].sampler);
+            }
+        }
     }
     ret.entryCount = entryCount;
     ret.layout = bglayout;
@@ -2347,11 +2361,9 @@ DescribedBindGroup LoadBindGroup(const DescribedBindGroupLayout* bglayout, const
     ret.needsUpdate = true;
     ret.descriptorHash = 0;
 
-
     for(uint32_t i = 0;i < ret.entryCount;i++){
         ret.descriptorHash ^= bgEntryHash(ret.entries[i]);
     }
-    //ret.bindGroup = wgpuDeviceCreateBindGroup((WGPUDevice)GetDevice(), &ret.desc);
     return ret;
 }
 


### PR DESCRIPTION
Previously `LoadBindGroup` only did a `memcpy` when creating the entries and didn't bother calling `wgpu...AddRef`, which could lead to a crash when calling UnloadBindGroup