### PR TITLE
Remove scaleFactor on MousePosition

### DIFF
--- a/src/platform/InitWindow_GLFW.c
+++ b/src/platform/InitWindow_GLFW.c
@@ -102,11 +102,7 @@ void cpcallback(GLFWwindow* window, double x, double y){
     RGWindowImpl* associatedWindow = CreatedWindowMap_get(&g_renderstate.createdSubwindows, window);
     //fprintf(stderr, "GLFWwindow is %p\n", window);
     assert(associatedWindow);
-    #ifdef __EMSCRIPTEN__
     associatedWindow->input_state.mousePos = CLITERAL(Vector2){(float)x, (float)y};
-    #else
-    associatedWindow->input_state.mousePos = CLITERAL(Vector2){(float)(x * associatedWindow->scaleFactor), (float)(y * associatedWindow->scaleFactor)};
-    #endif
 }
 
 #ifdef __EMSCRIPTEN__


### PR DESCRIPTION
For some reasons GetMousePosition was returning values that didn't reflect my actual mouse position. Deleting these lines fixed it. I can't explain why...